### PR TITLE
Update: docker-compose cash setting

### DIFF
--- a/Frontend/.dockerignore
+++ b/Frontend/.dockerignore
@@ -1,0 +1,38 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+*storybook.log

--- a/Frontend/dockerfile
+++ b/Frontend/dockerfile
@@ -9,4 +9,3 @@ RUN npm install
 COPY . .
 
 EXPOSE 3000
-CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,9 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - ./frontend:/Frontend
-      - /Frontend/node_modules
-      - /Frontend/.next
+      - ./Frontend:/app
+      - /app/node_modules
+      - /app/.next
     command: npm run dev
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
closed #49 

- The culprit for not being able to build the Frontend container is the huge amount of files.
  →To solve this, I added `.dockerignore` file which has the exact same codes as `.gitignore` file.

- The reason why local changes do not apply to the browser is cashing(volumes). 
  →I edited the "volumes" section on Frontend in `docker-compose.yml`