### PR TITLE
Feat: `MemoryProcessCard`

### DIFF
--- a/Frontend/src/components/ui/Common/MemoryProcessCard/index.stories.tsx
+++ b/Frontend/src/components/ui/Common/MemoryProcessCard/index.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MemoryProcessCard } from '.';
+
+const meta: Meta<typeof MemoryProcessCard> = {
+  component: MemoryProcessCard,
+  decorators: [
+    (Story) => (
+      <div className='w-60'>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    memoryProcess: 1,
+    wordCount: 10,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MemoryProcessCard>;
+
+export const Primary: Story = {
+  args: {},
+};

--- a/Frontend/src/components/ui/Common/MemoryProcessCard/index.stories.tsx
+++ b/Frontend/src/components/ui/Common/MemoryProcessCard/index.stories.tsx
@@ -5,7 +5,7 @@ const meta: Meta<typeof MemoryProcessCard> = {
   component: MemoryProcessCard,
   decorators: [
     (Story) => (
-      <div className='w-60'>
+      <div className='max-w-[240px]'>
         <Story />
       </div>
     ),

--- a/Frontend/src/components/ui/Common/MemoryProcessCard/index.tsx
+++ b/Frontend/src/components/ui/Common/MemoryProcessCard/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Box, Button, Card, Flex, Grid, Text } from '@radix-ui/themes';
+
+type Props = {
+  memoryProcess: number;
+  wordCount: number;
+};
+
+export const MemoryProcessCard: React.FC<Props> = (props) => {
+  return (
+    <Box width='100%'>
+      <Card>
+        <Flex align='center' justify='between'>
+          <Grid columns={{ initial: '1', md: '2' }} gap='3'>
+            <Grid columns={{ initial: '1', md: '2' }}>
+              <Text as='div' size='2' weight='bold'>
+                Memory process: {props.memoryProcess}/4
+              </Text>
+              <Text as='div' size='2' color='gray'>
+                {props.wordCount} words
+              </Text>
+            </Grid>
+            {/* TODO: replace a button */}
+            <Button variant='solid' className='text-white'>
+              Start now
+            </Button>
+          </Grid>
+          <Flex align='center'>
+            <div className='h-full w-full text-7xl font-extrabold text-[#F2F2F2]'>
+              {props.memoryProcess}
+            </div>
+          </Flex>
+        </Flex>
+      </Card>
+    </Box>
+  );
+};

--- a/Frontend/src/components/ui/Common/MemoryProcessCard/index.tsx
+++ b/Frontend/src/components/ui/Common/MemoryProcessCard/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const MemoryProcessCard: React.FC<Props> = (props) => {
   return (
     <Box width='100%'>
-      <Card className='relative'>
+      <Card className='relative p-6'>
         <Flex align='center' justify='between'>
           <Grid gap='3'>
             <Grid>
@@ -28,7 +28,7 @@ export const MemoryProcessCard: React.FC<Props> = (props) => {
           </Grid>
         </Flex>
         <Flex align='center'>
-          <div className='absolute right-0 top-1/2 z-[-1] -translate-y-1/2 text-[120px] font-extrabold text-[#F2F2F2]'>
+          <div className='absolute right-2 top-1/2 z-[-1] -translate-y-1/2 text-[120px] font-extrabold text-[#F2F2F2]'>
             {props.memoryProcess}
           </div>
         </Flex>

--- a/Frontend/src/components/ui/Common/MemoryProcessCard/index.tsx
+++ b/Frontend/src/components/ui/Common/MemoryProcessCard/index.tsx
@@ -10,10 +10,10 @@ type Props = {
 export const MemoryProcessCard: React.FC<Props> = (props) => {
   return (
     <Box width='100%'>
-      <Card>
+      <Card className='relative'>
         <Flex align='center' justify='between'>
-          <Grid columns={{ initial: '1', md: '2' }} gap='3'>
-            <Grid columns={{ initial: '1', md: '2' }}>
+          <Grid gap='3'>
+            <Grid>
               <Text as='div' size='2' weight='bold'>
                 Memory process: {props.memoryProcess}/4
               </Text>
@@ -26,11 +26,11 @@ export const MemoryProcessCard: React.FC<Props> = (props) => {
               Start now
             </Button>
           </Grid>
-          <Flex align='center'>
-            <div className='h-full w-full text-7xl font-extrabold text-[#F2F2F2]'>
-              {props.memoryProcess}
-            </div>
-          </Flex>
+        </Flex>
+        <Flex align='center'>
+          <div className='absolute right-0 top-1/2 z-[-1] -translate-y-1/2 text-[120px] font-extrabold text-[#F2F2F2]'>
+            {props.memoryProcess}
+          </div>
         </Flex>
       </Card>
     </Box>


### PR DESCRIPTION
close: #59 

- created `MemoryProcessCard`
- add Storybook

note:
- we can adjust the width by the parent div
- The Button will be replaced after the implementation is done
- not sure we can set `wordCount` and `memoryProcess` values by props 🤔 
